### PR TITLE
pkgs(python3-rasterio): fix execution of Python test suite

### DIFF
--- a/pkgs/rasterio/default.nix
+++ b/pkgs/rasterio/default.nix
@@ -68,12 +68,17 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
+    boto3
     hypothesis
     packaging
     pytest-randomly
     pytestCheckHook
     shapely
   ];
+
+  preCheck = ''
+    rm -r rasterio # prevent importing local rasterio
+  '';
 
   pytestFlagsArray = [
     "-m 'not network'"
@@ -88,13 +93,6 @@ buildPythonPackage rec {
   ];
 
   doInstallCheck = true;
-
-  installCheckPhase = ''
-    $out/bin/rio --show-versions | grep -E "rasterio:\s${version}" > /dev/null
-    $out/bin/rio --show-versions | grep -E "GDAL:\s[0-9]+(\.[0-9]+)*" > /dev/null
-    $out/bin/rio --show-versions | grep -E "PROJ:\s[0-9]+(\.[0-9]+)*" > /dev/null
-    $out/bin/rio --show-versions | grep -E "GEOS:\s[0-9]+(\.[0-9]+)*" > /dev/null
-  '';
 
   meta = with lib; {
     description = "Python package to read and write geospatial raster data";


### PR DESCRIPTION
Remove installCheckPhase declaration to allow rasterio Python test suite
to run.
